### PR TITLE
Metric bugfixes

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import time
+from benchmark.benchmark_utils import print_info
 from rouge_score import rouge_scorer
 from typeguard import typechecked
 from typing import Any, Dict, List, Tuple, Optional
@@ -56,8 +57,8 @@ class Executor:
         }
         """
         if self.verbose:
-            print(f"task_id: {task['id']}")
-            print(f"query: {task['query']}")
+            print_info(f"task_id: {task['id']}")
+            print_info(f"query: {task['query']}\n\n")
         if parent_task_query is not None:
             query = f"Your end goal is to answer this overall question: {parent_task_query}, please answer the following question:\n {task['query']} \n\n"
         else:

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import glob
 import json
@@ -6,7 +7,6 @@ import os
 import re
 import time
 from benchmark.benchmark_utils import print_info
-from rouge_score import rouge_scorer
 from typeguard import typechecked
 from typing import Any, Dict, List, Tuple, Optional
 
@@ -72,12 +72,14 @@ class Executor:
         start_time = time.time()
         system_overall_response = self.system.serve_query(query=query, query_id=task["id"], subset_files = deepresearch_subset)
         end_time = time.time()
+        token_usage = system_overall_response.get("token_usage", 0)
         model_output = system_overall_response["explanation"]
         code_string = system_overall_response["pipeline_code"]
         response = {}
         response["task_id"] = task["id"]
         response["model_output"] = model_output
         response["code"] = code_string
+        response["sut_token_usage"] = token_usage
         if "subtasks" in task and self.run_subtasks:
             response["subresponses"] = []
             for subtask in task["subtasks"]:
@@ -185,7 +187,6 @@ class Evaluator:
             for answer_type in self.answer_type_fixtures:
                 self.answer_to_metric_dict[answer_type["name"]] = answer_type["metrics"]
         
-        self.rouge_score_engine = rouge_scorer.RougeScorer(['rougeL'], use_stemmer=True)
         self.pipeline_evaluation_engine = GPTInterface(model="gpt-4o-mini")
         self.run_subtasks = run_subtasks
         self.evaluate_pipeline = evaluate_pipeline
@@ -206,6 +207,7 @@ class Evaluator:
         Returns:
             float: Computed score.
         """
+        token_usage = 0
         try:
             system_answer = system_response["answer"]
         except Exception as e:
@@ -228,61 +230,71 @@ class Evaluator:
         return (score, token_usage)
 
     @typechecked
-    def _evaluate_result_for_task(self, response: Dict[str, Any], task: Dict[str, Any], evaluate_pipeline=True) -> Tuple[List[Dict[str, Any]], int, int, int]:
+    def _evaluate_result_for_task(self, response: Dict[str, Any], task: Dict[str, Any], evaluate_pipeline=True) -> List[Dict[str, Any]]:
         """
         Evaluate results on all applicable metrics as specified in the task fixture for a 
         task in the workload.
         The caller should format the responses in the same structure as the workload.
+
+        Output format:
+        [
+            {"task_id": str,
+             ... the same fields as in response ...
+             "metric1": float,
+             "metric2": float,
+                ...
+             "token_usage_metrics": int, Contains total token usage for all metrics evaluation
+             "token_usage_pipeline": int, Contains total token usage for pipeline evaluation
+             "token_usage_subtasks": int Contains total token usage for all subtask evaluations
+            },
+            ... subtasks ...
+            ]
         """
-        all_evaluation_results = []
-        target_metrics = self.answer_to_metric_dict[task['answer_type']]
+
         assert(task["id"] == response["task_id"])
-        evaluation_result = {"task_id": task["id"]}
-        evaluation_result["runtime"] = response.get("combined_runtime",0)
-        total_token_usage_answers = 0
+
+        evaluation_result = copy.deepcopy(response)
+
+        target_metrics = self.answer_to_metric_dict[task['answer_type']]
+        total_token_usage_metrics = 0
         for metric in target_metrics:
             score, token_usage = self.evaluate_response_with_metric(task["id"], 
                                                                     response["model_output"], 
                                                                     task["answer"], 
                                                                     metric)
             evaluation_result[metric] = score
-            total_token_usage_answers += token_usage
+            total_token_usage_metrics += token_usage
+        evaluation_result["token_usage_metrics"] = total_token_usage_metrics
 
-        total_token_usage_pipeline = 0
+        token_usage_pipeline = 0
         if evaluate_pipeline:
             code_eval_list = []
-            code_eval_list, total_token_usage_pipeline = self.pipeline_evaluation_engine.evaluate_data_pipeline(sut_generated_pipeline=response["code"],task=task)
+            code_eval_list, token_usage_pipeline = self.pipeline_evaluation_engine.evaluate_data_pipeline(sut_generated_pipeline=response["code"],task=task)
             evaluation_result["llm_code_eval"] = code_eval_list
+            evaluation_result["token_usage_pipeline_eval"] = token_usage_pipeline
 
-        all_evaluation_results.append(evaluation_result)
-        total_token_usage_subtasks = 0
+        evaluation_result["token_usage_subtask_eval"] = 0
+        subtask_results = []
         if "subtasks" in task and self.run_subtasks:
             assert "subresponses" in response, "Subresponses should be present if subtasks are run! Please run the evaluation with run_subtasks=True."
             for i, subtask in enumerate(task["subtasks"]):
-                subtask_result, token_usage, pipeline_usage, total_subtask_usage = self._evaluate_result_for_task(response["subresponses"][i], subtask, evaluate_pipeline=False)
-                all_evaluation_results.extend(subtask_result)
-                total_token_usage_subtasks += token_usage
-        return (all_evaluation_results, total_token_usage_answers, total_token_usage_pipeline, total_token_usage_subtasks)
+                subtask_result = self._evaluate_result_for_task(response["subresponses"][i], subtask, evaluate_pipeline=False)
+                subtask_results.extend(subtask_result)
+                evaluation_result['token_usage_subtask_eval'] += subtask_result[0]['token_usage_subtask_eval']
+
+        return [evaluation_result]+subtask_results
 
     def evaluate_results(self, responses: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Evaluate results on all applicable metrics as specified in the task fixtures.
         The caller should format the responses in the same structure as the workload.
         """
-        all_evaluation_results = []
-        total_token_usage_answers = 0
-        total_token_usage_pipeline = 0
-        total_token_usage_subtasks = 0
+        all_eval_results = []
         for task_idx, task in enumerate(self.workload):
-            evaluation_results, token_usage_answers, token_usage_pipeline, token_usage_subtasks = self._evaluate_result_for_task(responses[task_idx], task, evaluate_pipeline=self.evaluate_pipeline)
-            all_evaluation_results.extend(evaluation_results)
-            total_token_usage_answers += token_usage_answers
-            total_token_usage_pipeline += token_usage_pipeline
-            total_token_usage_subtasks += token_usage_subtasks
-
+            results = self._evaluate_result_for_task(responses[task_idx], task, evaluate_pipeline=self.evaluate_pipeline)
+            all_eval_results.extend(results)
         # TODO: Implement workload-wise code understanding evaluation.
-
-        return all_evaluation_results, total_token_usage_answers, total_token_usage_pipeline, total_token_usage_subtasks
+        return all_eval_results
 
 class Benchmark:
     def __init__ (
@@ -334,11 +346,9 @@ class Benchmark:
         # Add processing time to each result
         for task_result in results:
             try:
-                task_result["processing_time"] = processing_time/len(results)
-                task_result["combined_runtime"] = task_result["runtime"] + task_result["processing_time"]
+                task_result["runtime"] += processing_time/len(results)
             except KeyError:
-                task_result["processing_time"] = -1
-                task_result["combined_runtime"] = -1
+                pass
 
         print("Evaluating results...")
         eval_start_time = time.time()
@@ -352,5 +362,5 @@ class Benchmark:
         eval_results = evaluator.evaluate_results(results)
         eval_end_time = time.time()
         print(f"Evaluation took time {eval_end_time - eval_start_time}")
-        return results, eval_results
+        return eval_results
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -79,7 +79,7 @@ class Executor:
         response["task_id"] = task["id"]
         response["model_output"] = model_output
         response["code"] = code_string
-        response["sut_token_usage"] = token_usage
+        response["token_usage_sut"] = token_usage
         if "subtasks" in task and self.run_subtasks:
             response["subresponses"] = []
             for subtask in task["subtasks"]:

--- a/benchmark/benchmark_utils.py
+++ b/benchmark/benchmark_utils.py
@@ -24,3 +24,16 @@ def generate_key_functionalities_for_workload(workload_filepath: str | os.PathLi
             print(f"generate_key_functionalities_for_workload stopped at {i} for {workload_filepath}.")
             print(e)
             break
+
+
+def print_error(text: str):
+    """ Print text in red color to indicate an error."""
+    print(f"\033[91m{text}\033[0m")
+
+def print_info(text: str):
+    """ Print text in green color to indicate success."""
+    print(f"\033[92m{text}\033[0m")
+
+def print_warning(text: str):
+    """ Print text in yellow color to indicate a warning."""
+    print(f"\033[93m{text}\033[0m")

--- a/benchmark/fixtures/answer_type_fixtures.json
+++ b/benchmark/fixtures/answer_type_fixtures.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "string_approximate",
-        "metrics": ["bleu", "rouge", "llm_paraphrase", "string_bootstrap"]
+        "metrics": ["string_bootstrap"]
     },
     {
         "name": "numeric_exact",

--- a/benchmark/fixtures/answer_type_fixtures.json
+++ b/benchmark/fixtures/answer_type_fixtures.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "string_approximate",
-        "metrics": ["string_bootstrap"]
+        "metrics": ["llm_paraphrase"]
     },
     {
         "name": "numeric_exact",

--- a/benchmark/fixtures/answer_type_fixtures.json
+++ b/benchmark/fixtures/answer_type_fixtures.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "numeric_approximate",
-        "metrics": ["mean_absolute_error", "mean_squared_error", "mean_relative_absolute_error", "rae_score"]
+        "metrics": ["mean_absolute_error", "mean_squared_error", "rae_score"]
     },
     {
         "name": "string_approximate",

--- a/benchmark/fixtures/answer_type_fixtures.json
+++ b/benchmark/fixtures/answer_type_fixtures.json
@@ -5,7 +5,7 @@
     },
     {
         "name": "string_approximate",
-        "metrics": ["bleu", "rouge", "llm_paraphrase"]
+        "metrics": ["bleu", "rouge", "llm_paraphrase", "string_bootstrap"]
     },
     {
         "name": "numeric_exact",

--- a/benchmark/metrics.py
+++ b/benchmark/metrics.py
@@ -261,6 +261,23 @@ class LLMParaphrase(Metric):
             return (int(is_paraphrase), token_usage)
         return (None, token_usage)
 
+class StringBootstrap(Metric):
+    name = "string_bootstrap"
+
+    def __call__(self, predicted: str, target: str):
+        """ arguments:
+            predicted: predicted string
+            target: target string
+        """
+        llm_paraphrase, token_usage = LLMParaphrase()(predicted, target)
+        if int(llm_paraphrase) > 0:
+            return (1.0, token_usage)
+        bleu, _ = BleuScore()(predicted, target)
+        if bleu > 0.2:
+            rouge, _ = RougeScore()(predicted, target)
+            return (rouge, token_usage)
+        return (0.0, token_usage)
+
 
 class Success(Metric):
     name = "success"
@@ -288,6 +305,7 @@ def metric_factory(metric_name: str):
         "f1_approximate": F1Approximate,
         "bleu": BleuScore,
         "rouge": RougeScore,
+        "string_bootstrap": StringBootstrap,
         "llm_paraphrase": LLMParaphrase,
         "success": Success,
         "mean_squared_error": MeanSquaredError,

--- a/benchmark/metrics.py
+++ b/benchmark/metrics.py
@@ -110,7 +110,7 @@ class F1(Metric):
             f1 = 2 * precision * recall / (precision + recall)
             return (f1, 0)
         except Exception as e:
-            logging.error(f"F1 Metric: {e}")
+            logging.warning(f"F1Approximate Metric defaults to 0 because of following exception: {e}")
             return (0.0, 0)
 
 class F1Approximate(Metric):
@@ -163,7 +163,7 @@ class F1Approximate(Metric):
             f1 = 2 * precision * recall / (precision + recall)
             return (f1, total_token_usage)
         except Exception as e:
-            logging.error(f"F1Approximate Metric: {e}")
+            logging.warning(f"F1Approximate Metric defaults to 0 because of following exception: {e}")
             return (0.0, total_token_usage)
 
 class MeanSquaredError(Metric):
@@ -178,7 +178,7 @@ class MeanSquaredError(Metric):
                 target = str_to_float(target)
             return ((predicted - target) * (predicted - target), 0)
         except Exception as e:
-            logging.error(f"MeanSquared Error Metric: {e}")
+            logging.warning(f"MeanSquaredError Metric defaults to None because of following exception: {e}")
             return (None, 0)
     
 class MeanAbsoluteError(Metric):
@@ -193,7 +193,7 @@ class MeanAbsoluteError(Metric):
                 target = str_to_float(target)
             return (abs(predicted - target), 0)
         except Exception as e:
-            logging.error(f"MeanAbsoluteError Metric: {e}")
+            logging.warning(f"MeanAbsoluteError Metric defaults to None because of following exception: {e}")
             return (None, 0)
 
 class MeanRelativeAbsoluteError(Metric):
@@ -209,7 +209,7 @@ class MeanRelativeAbsoluteError(Metric):
                 target = str_to_float(target)
             return (abs(predicted - target) / abs(target), 0)
         except Exception as e:
-            logging.error(f"MeanRelativeAbsoluteError Metric: {e}")
+            logging.warning(f"MeanRelativeAbsoluteError Metric defaults to 9999.0 because of following exception: {e}")
             return (9999.0, 0)
 
 class RAEScore(Metric):
@@ -225,15 +225,16 @@ class RAEScore(Metric):
             rae = abs(predicted - target) / abs(target)
             return (1/(1+rae), 0)
         except Exception as e:
-            logging.error(f"RAEScore Metric: {e}")
-            return (9999.0, 0)
+            logging.warning(f"RAEScore Metric defaults to 0 because of following exception: {e}")
+            return (0.0, 0)
 
 
 class BleuScore(Metric):
     name = "bleu"
 
     def __call__(self, predicted: str, target: str):
-        BLEUscore = nltk.translate.bleu_score.sentence_bleu([target], predicted)
+        cc = nltk.translate.bleu_score.SmoothingFunction()
+        BLEUscore = nltk.translate.bleu_score.sentence_bleu([target], predicted, smoothing_function=cc.method1)
         return (BLEUscore, 0)
 
 
@@ -276,7 +277,7 @@ class Success(Metric):
             else:
                 return (int(predicted == target), 0)
         except Exception as e:
-            logging.error(f"Success Metric: {e}")
+            logging.warning(f"Success Metric defaults to 0 because of following exception: {e}")
         return (0, 0)
 
 def metric_factory(metric_name: str):

--- a/evaluate.py
+++ b/evaluate.py
@@ -91,7 +91,7 @@ def main():
     parser.add_argument("--use_deepresearch_subset", action="store_true", default=False, help="Whether to use the subset of files from deepresearch experiments. Default: False")
     parser.add_argument("--verbose", action="store_true", default=False, help="Verbose logging. Default: False")
     parser.add_argument("--run_subtasks", action="store_true", help="Run subtasks if set. Default: False")
-    parser.add_argument("--no_pipeline_eval", action="store_false", help="Skip pipeline design and implementation evaluation (which uses API calls). Default: False")
+    parser.add_argument("--no_pipeline_eval", action="store_true", help="Skip pipeline design and implementation evaluation (which uses API calls). Default: True")
     args = parser.parse_args()
 
     system_name = args.sut
@@ -198,8 +198,8 @@ def main():
 
     aggregated_df.to_csv(aggregated_results_path, index=False)
 
-    print("Done. Aggregated results:")
-    print(aggregated_df[aggregated_df["workload"] == workload_name])
+    # print("Done. Aggregated results:")
+    # print(aggregated_df[aggregated_df["workload"] == workload_name])
 
 
 if __name__ == "__main__":

--- a/evaluate.py
+++ b/evaluate.py
@@ -26,6 +26,7 @@ def aggregate_results(system_name, results_df):
                 "metric": metric,
                 "value_mean": mean,
                 "value_std": std,
+                "value_sum": group_dropped_na["value"].sum(),
                 "value_support": len(group_dropped_na),
                 "total_value_support": len(group)
             })
@@ -44,6 +45,7 @@ def aggregate_results(system_name, results_df):
                 "metric": metric,
                 "value_mean": np.mean(values),
                 "value_std": np.std(values),
+                "value_sum": sum(values),
                 "value_support": value_support,
                 "total_value_support": len(group)
             })

--- a/systems/dsguru/baseline_system.py
+++ b/systems/dsguru/baseline_system.py
@@ -1,6 +1,8 @@
+# type: ignore
 import os
 import sys
 import re
+from benchmark.benchmark_utils import print_error, print_warning
 
 sys.path.append("./")
 
@@ -73,7 +75,7 @@ class BaselineLLMSystem(System):
         for file_name in filenames:
             data = self.dataset[file_name]
             if self.verbose:
-                print(f"{self.name}: Reading {file_name}...")
+                print_warning(f"{self.name}: Reading {file_name}...")
             data_string += f"\nFile name: {file_name}\n"
             data_string += f"Column data types: {data.dtypes}\n"
             data_string += "Table:\n"
@@ -188,7 +190,7 @@ class BaselineLLMSystem(System):
         with open(prompt_fp, "w") as f:
             f.write(prompt)
         if self.verbose:
-            print(f"{self.name}: Prompt saved to {prompt_fp}")
+            print_warning(f"{self.name}: Prompt saved to {prompt_fp}")
         return prompt
 
     def extract_response(self, response, try_number: int):
@@ -204,12 +206,12 @@ class BaselineLLMSystem(System):
         with open(response_fp, "w") as f:
             f.write(response)
         if self.verbose:
-            print(f"{self.name}: Response saved to {response_fp}")
+            print_warning(f"{self.name}: Response saved to {response_fp}")
 
         # Parse token count and clean the response
         response, token_count = self.parse_token_used(response)
         if self.verbose:
-            print(f"{self.name}: Response token count: {token_count}")
+            print_warning(f"{self.name}: Response token count: {token_count}")
         # Save the token count to a file
         token_fp = os.path.join(self.question_output_dir, "_intermediate", f"token_count-{try_number}.txt")
         with open(token_fp, "w") as f:
@@ -317,7 +319,7 @@ class BaselineLLMSystem(System):
         # Check if the error file is empty
         if error_fp is not None:
             if os.path.getsize(error_fp) > 0:
-                print(
+                print_error(
                     f"ERROR: {self.name}: ** ERRORS ** found in {error_fp}. Skipping JSON update."
                 )
                 return self._format_answer_on_fail(
@@ -329,7 +331,7 @@ class BaselineLLMSystem(System):
             with open(output_fp, "r") as f:
                 output = json.load(f)
         except json.JSONDecodeError as e:
-            print(f"ERROR: {self.name}: ** ERRORS ** decoding output JSON: {e}")
+            print_error(f"ERROR: {self.name}: ** ERRORS ** decoding output JSON: {e}")
             return self._format_answer_on_fail(
                 answer, f"** ERRORS ** decoding output in {output_fp}"
             )
@@ -365,7 +367,7 @@ class BaselineLLMSystem(System):
             overall_answer = clean_nan(overall_answer)
             json.dump(overall_answer, f, indent=4)
         if self.verbose:
-            print(f"{self.name}: Updated JSON answer saved to {json_fp}")
+            print_warning(f"{self.name}: Updated JSON answer saved to {json_fp}")
         return overall_answer
 
     @typechecked
@@ -387,7 +389,7 @@ class BaselineLLMSystem(System):
         ]
         response = self.llm(messages)
         if self.debug:
-            print(f"{self.name}: Response:", response)
+            print_warning(f"{self.name}: Response:", response)
 
         # Process the response
         json_fp, code_fp = self.extract_response(response, try_number=0)

--- a/systems/dsguru/generator_utils.py
+++ b/systems/dsguru/generator_utils.py
@@ -7,7 +7,7 @@ import logging
 import os
 import time
 import ollama
-
+import anthropic
 from openai import OpenAI
 
 # from tenacity import retry, stop_after_attempt, wait_exponential
@@ -16,6 +16,7 @@ import PyPDF2
 
 OpenAIModelList = ["gpt-4o", "gpt-4o-mini", "gpt-4o-v", "gpt-4o-mini-v", "o3-2025-04-16"]
 TogetherModelList = ["google/gemma-2b-it", "meta-llama/Llama-2-13b-chat-hf", "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B","google/gemma-3-27b-it", "deepseek-ai/DeepSeek-R1", "Qwen/Qwen2.5-Coder-32B-Instruct", "meta-llama/Llama-3.3-70B-Instruct-Turbo"]
+ClaudeModelList = ["claude-3-7-sonnet-latest", "claude-3-5-haiku-latest", "claude-3-5-sonnet-latest"]
 
 def get_api_key(key: str) -> str:
     # get API key from environment or throw an exception if it's not set
@@ -38,6 +39,8 @@ class Generator:
             self.client = OpenAI(api_key=get_api_key("OPENAI_API_KEY"))
         elif model in TogetherModelList:
             self.client = Together(api_key=get_api_key("TOGETHER_API_KEY"))
+        elif model in ClaudeModelList:
+            self.client = anthropic.Anthropic(api_key=get_api_key("ANTHROPIC_API_KEY"))
         else:
             raise ValueError(f"Unsupported model: {model}")
         self.verbose = verbose
@@ -68,7 +71,14 @@ class Generator:
             )
             content = response.choices[0].message.content
             total_tokens = response.usage.total_tokens
-
+        # --- Claude ---
+        elif isinstance(self.client, anthropic.Anthropic):
+            response = self.client.messages.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}], # temperature is 0 by default
+                max_tokens=4000,
+            )
+            return response.content[0].text
         else:
             raise RuntimeError(f"Unsupported client type: {type(self.client)}")
 
@@ -85,20 +95,31 @@ class Generator:
         fatal_reason = None
         while retry_count < max_retries:
             try:
-                ################### use to be openai.Completion.create(), now ChatCompletion ###################
-                ################### also parameters are different, now messages=, used to be prompt= ###################
-                # note deployment_id=... not model=...
-                result = self.client.chat.completions.create(
-                    model=self.model,
-                    messages=messages,
-                    # temperature=0.2,
-                )
+                if self.model in ClaudeModelList:
+                    claude_messages = []
+                    for msg in messages:
+                        if msg['role'] == 'user':
+                            claude_messages.append({"role": "user", "content": msg['content']})
+                        elif msg['role'] == 'assistant':
+                            claude_messages.append({"role": "assistant", "content": msg['content']})
+                        # skip system messages
+                    messages = claude_messages
+                    result = self.client.messages.create(
+                        model=self.model,
+                        messages=messages,
+                        max_tokens=4000,
+                    )
+                else:
+                    result = self.client.chat.completions.create(
+                        model=self.model,
+                        messages=messages,
+                    )
                 
                 break # break out of while loop if no error
             
             except Exception as e:
                 print(f"An error occurred: {e}.")
-                if "context_length_exceeded" in f"{e}":
+                if "context_length_exceeded" in f"{e}" or "too long" in f"{e}":
                     fatal = True
                     fatal_reason = f"{e}"
                     break
@@ -115,8 +136,14 @@ class Generator:
             res = "Max retries reached. Skipping..."
         else:
             try:
-                res = result.choices[0].message.content
-                total_tokens = result.usage.total_tokens
+                if self.model in ClaudeModelList:
+                    res = result.content[0].text
+                    input_tokens = result.usage.input_tokens
+                    output_tokens = result.usage.output_tokens
+                    total_tokens = input_tokens + output_tokens
+                else: 
+                    res = result.choices[0].message.content
+                    total_tokens = result.usage.total_tokens
                 res = f"{res}\n\n{self.TOK_TAG}{total_tokens}]"
             except Exception as e:
                 print("Error:", e)


### PR DESCRIPTION
Added several features to streamline evaluation and have easier results reproducibility.

- Refactored metric computations (see `metrics.py` and `answer_type_fixtures.json`)
Now RAEScore and StringApproximation are not computed during aggregation, but as regular `Metric` during the workflow. Consequently, rouge, blue, and LLMParaphrase are encapsulated in the StringApproximation and RAE is encapsulated in RAEScore. This gives us a single point where to check for bugs/inconsistencies, and also exposes a single interface for all scripts that compute scores, since now the resulting `.csv` from the evaluation expose these metrics from the getgo rather than relying on future aggregations.
  
- Simplified dataset arguments for `evaluate.py`
Removed duplicate arguments `dataset_name` and `workload_filename`. Now are both folded into one argument `workload`. The scripts relies on having workload files named as `{workload}.json`. To support the `tiny` workloads, if the name of the workload contains the word `-tiny`, the dataset files chosen will still be from the original dataset (i.e., we simply strip `tiny` and access the relevant folder.

- Runtime and token usage for SUTs
Refactored some of the internal functionality that report runtime and token usage, both from SUTs as well as from evaluation. Important high level change, the `token_usage_...` numbers are propagated all the way through the evaluation pipeline as part of the results dictionaries, so the final `.csv` now contain a line for each task with each token usage. This allows for easier computation/aggregation of token usage based on the evaluation results.
Implementation detail: regarding token passing, the token usage is not appended as a string to the system output, but is stored in a dedicated variable within the Generator llm. This functionality allows a more transparent tracking of total token usage when systems try multiple retries or few shot execution.
Semantic change: to disambiguate the SUT token usage from the token usage when evaluating the answers, renamed the variable `total_token_answer` to `token_usage_metrics` and named the usage of tokens during processing of the queries as `token_usage_sut`.

Minor:
- Added convenience `print_error`, `print_info`, `print_warning` functions to print colored outputs in terminal
- Removed duplicate Generator.generate() method which was unused 