### PR TITLE
Fix wildfire-hard-20 answer: use percentage (4.65) instead of proportion (0.0465)

### DIFF
--- a/solutions/wildfire/wildfire-hard-20.py
+++ b/solutions/wildfire/wildfire-hard-20.py
@@ -14,4 +14,4 @@ for idx, fire_row in noaa_fire_data_2008_sorted_df.iterrows():
     if cur_agg >= damage_threshold:
         result_idx = idx
         break
-print(f"The percentage of wildfires accounting for 90% of residential house damage in 2008 is {result_idx/len(noaa_fire_data_2008_df)}%")
+print(f"The percentage of wildfires accounting for 90% of residential house damage in 2008 is {result_idx/len(noaa_fire_data_2008_df) * 100}%")

--- a/workload/wildfire.json
+++ b/workload/wildfire.json
@@ -14517,7 +14517,7 @@
     {
         "id": "wildfire-hard-20",
         "query": "According to NOAA, what percentage (to 2 decimal places) of wildfires account for at least 90% of residential houses damaged in 2008?",
-        "answer": 0.0465,
+        "answer": 4.65,
         "answer_type": "numeric_exact",
         "data_sources": [
             "noaa_wildfires.csv",
@@ -14598,7 +14598,7 @@
                 "id": "wildfire-hard-20-7",
                 "step": "Calculate the percentage of fires needed to reach the 90 % damage threshold by dividing that index value by the total count of 2008 fires and print the result.",
                 "query": "What percentage of the 2008 fires account for 90% of residential house damage? Give the percentage score and round to 4 decimal places.",
-                "answer": 0.0465,
+                "answer": 4.65,
                 "answer_type": "numeric_exact",
                 "data_sources": [
                     "noaa_wildfires.csv"


### PR DESCRIPTION
## Summary
- The wildfire-hard-20 query asks for "percentage (to 2 decimal places)" but the answer key had `0.0465` (the proportion) instead of `4.65` (the percentage)
- Fixed the main answer and subtask wildfire-hard-20-7 answer in `workload/wildfire.json`
- Fixed the solution script (`solutions/wildfire/wildfire-hard-20.py`) to multiply by 100
- Note: `dr-input/wildfire/wildfire_random.json` already had the correct value of `4.65`
- For reference, wildfire-hard-19 correctly uses `32.76` (not `0.3276`) for its percentage answer

## Test plan
- [ ] Verify the answer `4.65` matches the output of the corrected solution script
- [ ] Confirm consistency with `dr-input/wildfire/wildfire_random.json` (already has `4.65`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)