### PR TITLE
Add astronomy_alternative.json: corrected gold for astronomy-easy-2, whose data_sources cut off at midnight of July 21 and miss the true peak (7.52 -> 6.374)

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -111,7 +111,10 @@ def main():
         dataset_name = workload.replace("-tiny", "")
         dataset_directory = os.path.join(project_root_dir, f"data/{dataset_name}/tiny")
     else:
-        dataset_name = workload
+        # "<domain>_alternative" workloads (e.g. astronomy_alternative.json) hold
+        # alternative gold answers for tasks of an existing domain and run
+        # against that domain's data directory.
+        dataset_name = workload.replace("_alternative", "")
 
     results_df = None
     if args.use_evaluation_cache:

--- a/solutions/astronomy_alternative/astronomy-easy-2.py
+++ b/solutions/astronomy_alternative/astronomy-easy-2.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+# Alternative solution for astronomy-easy-2 that covers the FULL calendar days
+# named in the query. The 3-day density files end exactly at midnight of their
+# final day, so swarma-wu016 / swarma-wu545 contain only the first instant of
+# March 17 2014 / July 21 2018. The remainder of those days lives in the
+# subsequent files (swarma-wu017 / swarma-wu546); the true July peak occurs on
+# 2018-07-21 13:10:00 and is only visible there.
+
+import pandas as pd
+import os
+
+# --- Configuration ---
+BASE_DATA_DIR = '../../data/astronomy/input/STORM-AI/warmup/v2/'
+DENSITY_DIR = os.path.join(BASE_DATA_DIR, 'Sat_Density/')
+
+# Files covering each period, including the day that spills into the next file
+PERIOD_1_FILES = [  # March 14th-17th 2014
+    'swarma-wu016-20140314_to_20140317.csv',
+    'swarma-wu017-20140317_to_20140320.csv',
+]
+PERIOD_2_FILES = [  # July 18th-21st 2018
+    'swarma-wu545-20180718_to_20180721.csv',
+    'swarma-wu546-20180721_to_20180724.csv',
+]
+PERIOD_1_WINDOW = ('2014-03-14', '2014-03-18')  # [start, end)
+PERIOD_2_WINDOW = ('2018-07-18', '2018-07-22')
+
+DENSITY_COL = 'Orbit Mean Density (kg/m^3)'
+TIME_COL = 'Timestamp'
+
+
+# --- Function to Load and Find Peak ---
+def find_peak_density(file_names, window, density_col_name, time_col_name):
+    """Loads the files, restricts to the window, and returns the peak density."""
+    frames = []
+    for name in file_names:
+        path = os.path.join(DENSITY_DIR, name)
+        if not os.path.exists(path):
+            raise FileNotFoundError(f"File not found: {path}")
+        print(f"Loading data from: {path}")
+        frames.append(pd.read_csv(path, parse_dates=[time_col_name]))
+    df = pd.concat(frames, ignore_index=True).sort_values(by=time_col_name)
+
+    if density_col_name not in df.columns:
+        raise ValueError(f"Density column '{density_col_name}' not found.")
+
+    # Clean invalid measurements (n/a values or 9.99E32 sentinels)
+    df[density_col_name] = pd.to_numeric(df[density_col_name], errors='coerce')
+    df = df[df[density_col_name].notna() & (df[density_col_name] < 1e30)]
+
+    start, end = window
+    df = df[(df[time_col_name] >= start) & (df[time_col_name] < end)]
+    if df.empty:
+        raise ValueError(f"No data in window {window}")
+
+    peak_density = df[density_col_name].max()
+    peak_time = df.loc[df[density_col_name].idxmax(), time_col_name]
+    print(f"  Peak density found: {peak_density:.3e} at {peak_time}")
+    return peak_density
+
+
+# --- Load Data and Analyze ---
+try:
+    peak_1 = find_peak_density(PERIOD_1_FILES, PERIOD_1_WINDOW, DENSITY_COL, TIME_COL)
+    peak_2 = find_peak_density(PERIOD_2_FILES, PERIOD_2_WINDOW, DENSITY_COL, TIME_COL)
+
+    # --- Compare Peaks ---
+    print(f"\n--- Peak Density Comparison ---")
+    print(f"Peak Density in Period 1 (March 14th-17th 2014): {peak_1:.3e}")
+    print(f"Peak Density in Period 2 (July 18th-21st 2018): {peak_2:.3e}")
+
+    if peak_1 > 0:  # Avoid division by zero if peak1 is zero or negative
+        ratio = peak_1 / peak_2
+        print(f"Ratio (Peak 1 / Peak 2): {ratio:.3f}")
+    else:
+        print("Cannot calculate ratio as Peak 1 is zero or negative.")
+
+except FileNotFoundError as fnf_error:
+    print(f"ERROR: {fnf_error} - Please ensure file names and paths are correct.")
+except ValueError as ve:
+    print(f"ERROR: Data processing error - {ve}")
+except KeyError as ke:
+    print(f"ERROR: Column name not found - {ke}. Please verify column names.")
+except Exception as e:
+    print(f"An unexpected error occurred: {e}")

--- a/workload/astronomy_alternative.json
+++ b/workload/astronomy_alternative.json
@@ -1,0 +1,84 @@
+[
+    {
+        "id": "astronomy-easy-2",
+        "query": "Calculate the ratio of peak atmospheric mass density experienced by Swarm A satellite during March 14th-17th 2014 vs July 18th-21st 2018.",
+        "answer": 6.374,
+        "answer_type": "numeric_exact",
+        "runtime": 0.1,
+        "data_sources": [
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+        ],
+        "subtasks": [
+            {
+                "id": "astronomy-easy-2-1",
+                "step": "Read the density files covering the two windows. Each 3-day file ends exactly at midnight of its final day, so swarma-wu016 and swarma-wu545 only contain the first instant (00:00) of March 17 and July 21; the remainder of those days lives in the subsequent files swarma-wu017 and swarma-wu546.",
+                "query": "Identify the files containing the density data for March 14th-17th 2014 and July 18th-21st 2018, covering the full final days",
+                "answer": [
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+                ],
+                "data_sources": [
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+                ],
+                "answer_type": "list_exact"
+            },
+            {
+                "id": "astronomy-easy-2-2",
+                "step": "Identify that 'Orbit Mean Density (kg/m^3)' holds the atmospheric mass density measurement. Record the maximum value found in the density column between 2014-03-14 00:00 and 2014-03-18 00:00 (the peak occurs 2014-03-14 13:50, inside swarma-wu016).",
+                "query": "What is the maximum value of the atmospheric mass density during March 14th-17th 2014 recorded from the data?",
+                "answer": 1.329e-12,
+                "answer_type": "numeric_exact",
+                "data_sources": [
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv"
+                ]
+            },
+            {
+                "id": "astronomy-easy-2-3",
+                "step": "Record the maximum value found in the density column between 2018-07-18 00:00 and 2018-07-22 00:00. The peak occurs 2018-07-21 13:10 and therefore lies in swarma-wu546, not in swarma-wu545 (whose last row is 2018-07-21 00:00).",
+                "query": "What is the maximum value of the atmospheric mass density during July 18th-21st 2018 recorded from the data?",
+                "answer": 2.084e-13,
+                "answer_type": "numeric_exact",
+                "data_sources": [
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+                ]
+            },
+            {
+                "id": "astronomy-easy-2-4",
+                "step": "Compute the ratio peak_Mar2014 / peak_Jul2018, but only if the first peak is positive to avoid divide-by-zero or sign issues.",
+                "query": "What is the calculated ratio of the peak densities if the peak density in March 2014 is greater than zero?",
+                "answer": 6.374,
+                "data_sources": [
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+                ],
+                "answer_type": "numeric_exact"
+            }
+        ],
+        "deepresearch_subset": [
+            "STORM-AI/warmup/v2/OMNI2/omni2-wu091-20140826_to_20141025.csv",
+            "space-track/58214_storm.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu260-20160315_to_20160318.csv",
+            "STORM-AI/warmup/v2/OMNI2/omni2-wu492-20171211_to_20180209.csv",
+            "swarm/POD/SW_OPER_SP3ACOM_2__20190927T235942_20190928T235942_0201/SW_OPER_SP3ACOM_2__20190927T235942_20190928T235942_0201.sp3",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu553-20180811_to_20180814.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu593-20181209_to_20181212.csv",
+            "STORM-AI/warmup/v2/OMNI2/omni2-wu224-20150929_to_20151128.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+            "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv"
+        ]
+    }
+]


### PR DESCRIPTION
The 3-day Sat_Density files end at midnight of their final day, so the original gold (7.52) misses the true July peak (2.084e-13 at 2018-07-21 13:10, in swarma-wu546). This alternative workload reads the date ranges as full calendar days: answer 6.374 = 1.329e-12 / 2.084e-13, with data_sources, subtasks, deepresearch_subset, and a matching solution script updated. evaluate.py maps <domain>_alternative workloads onto the existing domain data dir. Also fixes subtask 2-3's data_sources, which pointed at the March file.