### PR TITLE
Support accepted_answers alternate golds; apply to astronomy-easy-2

### DIFF
--- a/benchmark/evaluator.py
+++ b/benchmark/evaluator.py
@@ -47,7 +47,7 @@ class Evaluator:
         """Normalize a string by removing spaces, punctuation, and making it lowercase."""
         return re.sub(r'[^a-z0-9]', '', s.lower())
 
-    def evaluate_response_with_metric(self, task_id: str, system_response: Dict, target_answer: str | int | float, metric_name: str) -> Tuple[float, int, int, int]:
+    def evaluate_response_with_metric(self, task_id: str, system_response: Dict, target_answer: str | int | float | list, metric_name: str) -> Tuple[float, int, int, int]:
         """
         Evaluate a single system response against a target answer using the specified metric.
 
@@ -111,18 +111,32 @@ class Evaluator:
         evaluation_result = copy.deepcopy(response)
 
         target_metrics = self.answer_to_metric_dict[task['answer_type']]
+        # A task may declare `accepted_answers`: alternate golds (each shaped like
+        # `answer`) that are equally valid, e.g. when the query admits two defensible
+        # readings. Each metric is scored against every candidate and the best value
+        # is kept; tasks without `accepted_answers` behave exactly as before.
+        candidate_answers = [task["answer"]] + list(task.get("accepted_answers", []))
         total_token_usage_metrics = 0
         total_token_usage_metrics_input = 0
         total_token_usage_metrics_output = 0
         for metric in target_metrics:
-            score, token_usage, token_usage_input, token_usage_output = self.evaluate_response_with_metric(task["id"], 
-                                                                    response["model_output"], 
-                                                                    task["answer"], 
-                                                                    metric)
-            evaluation_result[metric] = score
-            total_token_usage_metrics += token_usage
-            total_token_usage_metrics_input += token_usage_input
-            total_token_usage_metrics_output += token_usage_output
+            best_score = None
+            higher_is_better = metric_factory(metric).higher_is_better
+            for candidate in candidate_answers:
+                score, token_usage, token_usage_input, token_usage_output = self.evaluate_response_with_metric(task["id"],
+                                                                        response["model_output"],
+                                                                        candidate,
+                                                                        metric)
+                total_token_usage_metrics += token_usage
+                total_token_usage_metrics_input += token_usage_input
+                total_token_usage_metrics_output += token_usage_output
+                if score is None:
+                    continue
+                if best_score is None:
+                    best_score = score
+                else:
+                    best_score = max(best_score, score) if higher_is_better else min(best_score, score)
+            evaluation_result[metric] = best_score
         evaluation_result["token_usage_metrics"] = total_token_usage_metrics
         evaluation_result["token_usage_metrics_input"] = total_token_usage_metrics_input
         evaluation_result["token_usage_metrics_output"] = total_token_usage_metrics_output

--- a/benchmark/metrics.py
+++ b/benchmark/metrics.py
@@ -16,6 +16,10 @@ P = TypeVar('P')
 T = TypeVar('T')
 class Metric(Generic[P,T]):
     name = "Metric"
+    # Polarity used when a task lists multiple accepted answers and the best
+    # per-metric value across candidates is kept. Error-style metrics override
+    # this with False so "best" means the smallest value.
+    higher_is_better = True
 
     def __init__(self, *args, **kwargs):
         pass
@@ -249,6 +253,7 @@ class F1Approximate(Metric):
 class MeanSquaredError(Metric):
     # This method computes the squared error. The evaluation script is responsible for aggregating.
     name = "mean_squared_error"
+    higher_is_better = False
 
     def __call__(self, predicted: str | int | float, target: str | int | float):
         try:
@@ -264,6 +269,7 @@ class MeanSquaredError(Metric):
 class MeanAbsoluteError(Metric):
     # This method computes the squared error. The evaluation script is responsible for aggregating.
     name = "mean_absolute_error"
+    higher_is_better = False
 
     def __call__(self, predicted: str | int | float, target: str | int | float):
         try:
@@ -279,6 +285,7 @@ class MeanAbsoluteError(Metric):
 class MeanRelativeAbsoluteError(Metric):
     # This method computes the squared error. The evaluation script is responsible for aggregating.
     name = "mean_relative_absolute_error"
+    higher_is_better = False
 
     def __call__(self, predicted: str | int | float, target: str | int | float):
         logging.warning("DEPRECATION WARNING: Use RAEScore class instead!")

--- a/workload/astronomy.json
+++ b/workload/astronomy.json
@@ -98,6 +98,7 @@
         "id": "astronomy-easy-2",
         "query": "Calculate the ratio of peak atmospheric mass density experienced by Swarm A satellite during March 14th-17th 2014 vs July 18th-21st 2018.",
         "answer": 7.52,
+        "accepted_answers": [6.374],
         "answer_type": "numeric_exact",
         "runtime": 0.1,
         "data_sources": [
@@ -107,11 +108,19 @@
         "subtasks": [
             {
                 "id": "astronomy-easy-2-1",
-                "step": "Read swarma-wu016-20140314_to_20140317.csv and swarma-wu545-20180718_to_20180721.csv.",
+                "step": "Read swarma-wu016-20140314_to_20140317.csv and swarma-wu545-20180718_to_20180721.csv. Each 3-day file ends exactly at midnight of its final day, so reading the date ranges as full calendar days additionally requires swarma-wu017 and swarma-wu546, which hold the remainder of March 17 and July 21.",
                 "query": "Identify the files containing the density data for 2014 and 2018",
                 "answer": [
                     "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
                     "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv"
+                ],
+                "accepted_answers": [
+                    [
+                        "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
+                        "STORM-AI/warmup/v2/Sat_Density/swarma-wu017-20140317_to_20140320.csv",
+                        "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv",
+                        "STORM-AI/warmup/v2/Sat_Density/swarma-wu546-20180721_to_20180724.csv"
+                    ]
                 ],
                 "data_sources": [
                     "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
@@ -131,12 +140,13 @@
             },
             {
                 "id": "astronomy-easy-2-3",
-                "step": "Record the maximum value found in the density column (peak density) for July 2018",
+                "step": "Record the maximum value found in the density column (peak density) for July 2018. Within the swarma-wu545 file window (ending 2018-07-21 00:00) the peak is 1.767e-13; reading July 18th-21st as full calendar days, the peak is 2.084e-13 at 2018-07-21 13:10, which lies in swarma-wu546.",
                 "query": "What is the maximum value of the atmospheric mass density in July 2018 recorded from the data?",
                 "answer": 1.767e-13,
+                "accepted_answers": [2.084e-13],
                 "answer_type": "numeric_exact",
                 "data_sources": [
-                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv"
+                    "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv"
                 ]
             },
             {
@@ -144,6 +154,7 @@
                 "step": "Compute the ratio peak_Mar2014 / peak_Jul2018, but only if the first peak is positive to avoid divide-by-zero or sign issues.",
                 "query": "What is the calculated ratio of the peak densities if the peak density in March 2014 is greater than zero?",
                 "answer": 7.52,
+                "accepted_answers": [6.374],
                 "data_sources": [
                     "STORM-AI/warmup/v2/Sat_Density/swarma-wu016-20140314_to_20140317.csv",
                     "STORM-AI/warmup/v2/Sat_Density/swarma-wu545-20180718_to_20180721.csv"


### PR DESCRIPTION
Adds an optional `accepted_answers` field on tasks/subtasks: a list of alternate gold answers (each shaped like `answer`) that score as correct alongside the canonical answer, for queries admitting more than one defensible reading. The evaluator scores every metric against each candidate and keeps the best value (metrics carry a `higher_is_better` polarity so error metrics take the minimum). Tasks without the field are evaluated exactly as before; consumers unaware of the field still see the canonical `answer`.

Applied to astronomy-easy-2: "March 14th-17th 2014 vs July 18th-21st 2018" admits two readings. The 3-day Sat_Density files end at midnight of their final day, so the file-window reading gives the existing gold 7.52 (1.3285e-12 / 1.7666e-13), while reading the ranges as full calendar days gives 6.374: the true July full-day peak 2.084e-13 occurs 2018-07-21 13:10 inside swarma-wu546, outside the wu545 file window. Both are now accepted (task, subtasks 2-1/2-3/2-4); all values re-derived from the raw CSVs. Also fixes subtask 2-3's data_sources, which pointed at the March file.