### PR TITLE
Clarify legal-hard-15 wording to match its gold (include Micropolitan)

### DIFF
--- a/workload/legal.json
+++ b/workload/legal.json
@@ -3618,7 +3618,7 @@
     },
     {
         "id": "legal-hard-15",
-        "query": "How many total Identity Theft reports were there in 2024 from cross-state Metropolitan Statistical Areas?",
+        "query": "How many total Identity Theft reports were there in 2024 from cross-state statistical areas (Metropolitan or Micropolitan)?",
         "answer": 243377,
         "runtime": 1,
         "answer_type": "numeric_exact",
@@ -3739,8 +3739,8 @@
             },
             {
                 "id": "legal-hard-15-3",
-                "step": "Mark an MSA as cross-state possibly by checking whether the extracted state code string contains a hyphen ('-').",
-                "query": "How many cross-state MSAs are there?",
+                "step": "Mark a statistical area as cross-state possibly by checking whether the extracted state code string contains a hyphen ('-').",
+                "query": "How many cross-state statistical areas (Metropolitan or Micropolitan) are there?",
                 "answer": 43,
                 "answer_type": "numeric_exact",
                 "data_sources": [


### PR DESCRIPTION
The query asked for reports from cross-state "Metropolitan Statistical Areas", but the gold 243377 sums all 43 deduplicated cross-state statistical areas, including 2 cross-state Micropolitan Statistical Areas (LaGrange, GA-AL: 453 reports; Lebanon-Claremont, NH-VT: 242 reports). A system filtering on the literal wording computes 242682 (41 areas) and is scored wrong.

Reword the task and subtask 15-3 to "cross-state statistical areas (Metropolitan or Micropolitan)" so the query unambiguously matches the existing gold. No gold values change. Verified against the raw CSVs with the reference solution's recipe.